### PR TITLE
Fix a bug in experiments/run_redock.py: 'FlexPepDock' object has no attribute 'amber_relax' 

### DIFF
--- a/analysis/redock.py
+++ b/analysis/redock.py
@@ -131,7 +131,7 @@ class FlexPepDock:
         adcp_protocol(l, r, self.nproc)
     
     def interface_analyze(self, rosetta_script_path):
-        if self.amber_relax:
+        if self.soft_relax:
             file_to_relax = self.relaxed_file
         else:
             file_to_relax = self.fixed_file


### PR DESCRIPTION
Thank you for sharing the code, and quick response to my email.

A no attribution exception occurs when I run the following script:
`python experiments/run_redock.py --in_path tests/inference --ori_path examples/receptor_data --interface_analyzer_path your/path/to/rosetta/main/source/bin/rosetta_scripts.static.linuxgccrelease`

After checking the related code in the latest version of analysis/redock.py, I thought there is a typo in the variable name in this line of code, i.e. `self.amber_relax` --> `self.soft_relax`

https://github.com/YuzheWangPKU/DiffPepBuilder/blob/62dfd6b1eea2a8445236af9e8ebaa98d3f519bea/analysis/redock.py#L134

The captured exception is as following: 
![image](https://github.com/user-attachments/assets/38111af9-1e19-4cfd-8134-e941034613b8)
        